### PR TITLE
1.6.0-beta

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 from django.test import TestCase, RequestFactory, mock
 from django.contrib.auth import get_user_model
-from django.db.models import QuerySet
 from django.core import exceptions
 from django.http import HttpResponse
 

--- a/api/views.py
+++ b/api/views.py
@@ -93,7 +93,7 @@ class DatasetListViewSet(AuthenticatedViewSet):
     model_class = None
    
     def get_queryset(self):
-        return filter_visible(self.queryset, user=self.user)
+        return filter_visible(self.queryset.all(), user=self.user)
     
     def get_object(self):
         urn = self.kwargs.get('urn', None)

--- a/core/static/core/mavedb/base.css
+++ b/core/static/core/mavedb/base.css
@@ -163,14 +163,14 @@ table {
 
 
 #search-table {
-    border: 2px solid #987cb8;
+    border: 1px solid #987cb8;
     padding: 0 0.25px 0.25px 1px;
     display: block;
-    /*overflow-x: scroll;*/
+    overflow-x: scroll;
 }
 
 #counts-table, #scores-table {
-    border: 2px solid #987cb8;
+    border: 1px solid #987cb8;
     padding: 0 0.25px 0.25px 1px;
     display: block;
     min-width: 25% !important;
@@ -179,7 +179,7 @@ table {
 
 .styled-table {
     margin-bottom: 0; 
-    background: whitesmoke;
+    background: #f7f7f7;
 }
 .styled-table th {
     background: #dadff1;

--- a/data/main/site_info.json
+++ b/data/main/site_info.json
@@ -6,5 +6,5 @@
     "md_privacy": "",
     "md_terms": "",
     "md_usage_guide": "",
-    "version": "1.5.1-beta"
+    "version": "1.6.0-beta"
 }

--- a/dataset/serializers.py
+++ b/dataset/serializers.py
@@ -104,8 +104,7 @@ class ExperimentSerializer(DatasetModelSerializer):
             obj.parent_for_user(self.context.get('user', None)))
     
     def get_children(self, obj):
-        children_ = visible_children(
-            obj.children, user=self.context.get('user', None))
+        children_ = visible_children(obj, user=self.context.get('user', None))
         return [c.urn for c in children_]
 
     class Meta(DatasetModelSerializer.Meta):
@@ -119,8 +118,7 @@ class ExperimentSetSerializer(DatasetModelSerializer):
     experiments = serializers.SerializerMethodField('get_children')
 
     def get_children(self, obj):
-        children_ = visible_children(
-            obj.children, user=self.context.get('user', None))
+        children_ = visible_children(obj, user=self.context.get('user', None))
         return [c.urn for c in children_]
 
     class Meta(DatasetModelSerializer.Meta):

--- a/dataset/templates/dataset/scoreset/scoreset.html
+++ b/dataset/templates/dataset/scoreset/scoreset.html
@@ -207,7 +207,16 @@
         console.log(jqXHR.status);
         console.log(textStatus);
         console.log(errorThrown);
-        $("#scores-loading").text("Server error. Table could not be loaded.");
+        if (jqXHR.status === 500) {
+          $("#scores-loading p").text(
+            "An internal server error has occurred " +
+            "during your search request."
+          );
+        } else {
+          $("#scores-loading p").text(
+            "Your search request has failed with status " + jqXHR.status
+          );
+        }
       });
     });
 
@@ -238,7 +247,16 @@
         console.log(jqXHR.status);
         console.log(textStatus);
         console.log(errorThrown);
-        $("#counts-loading").text("Server error. Table could not be loaded.");
+        if (jqXHR.status === 500) {
+          $("#counts-loading p").text(
+            "An internal server error has occurred " +
+            "during your search request."
+          );
+        } else {
+          $("#counts-loading p").text(
+            "Your search request has failed with status " + jqXHR.status
+          );
+        }
       });
     });
   </script>

--- a/dataset/tests/test_models_dataset.py
+++ b/dataset/tests/test_models_dataset.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from accounts.factories import UserFactory
 
 from dataset import models
+from dataset.templatetags.dataset_tags import visible_children
 from dataset.factories import ExperimentSetFactory, ScoreSetFactory, \
     ExperimentFactory
 
@@ -110,7 +111,7 @@ class TestDatasetModel(TestCase):
         public_instance.private = False
         public_instance.save()
         
-        result = private_instance.experimentset.children_for_user(user)
+        result = visible_children(private_instance.experimentset, user)
         self.assertNotIn(private_instance, result)
         self.assertIn(public_instance, result)
         
@@ -124,22 +125,22 @@ class TestDatasetModel(TestCase):
         public_instance.private = False
         public_instance.save()
         
-        result = private_instance.experimentset.children_for_user(user)
+        result = visible_children(private_instance.experimentset, user)
         self.assertIn(private_instance, result)
         self.assertIn(public_instance, result)
         
     def test_children_for_exclude_private_user_is_none(self):
         private_instance = ExperimentFactory()
-        
+
         public_instance = ExperimentFactory(
             experimentset=private_instance.experimentset)
         public_instance.private = False
         public_instance.save()
-        
-        result = private_instance.experimentset.children_for_user(None)
+
+        result = visible_children(private_instance.experimentset, None)
         self.assertNotIn(private_instance, result)
         self.assertIn(public_instance, result)
-        
+
     def test_parent_for_user_none_if_parent_is_none(self):
         instance = ExperimentSetFactory()
         self.assertIsNone(instance.parent_for_user())

--- a/dataset/tests/test_views_experiment.py
+++ b/dataset/tests/test_views_experiment.py
@@ -260,7 +260,7 @@ class TestCreateNewExperimentView(TestCase, TestMessageMixin):
         request.user = self.user
         _ = ExperimentCreateView.as_view()(request)
         exp = Experiment.objects.all()[0]
-        self.assertFalse(self.user in exp.administrators)
+        self.assertTrue(self.user in exp.administrators)
 
     def test_new_experimentset_created_with_current_user_as_admin(self):
         data = self.post_data.copy()
@@ -269,7 +269,7 @@ class TestCreateNewExperimentView(TestCase, TestMessageMixin):
         _ = ExperimentCreateView.as_view()(request)
         exps = ExperimentSet.objects.first()
 
-        self.assertFalse(self.user in exps.administrators)
+        self.assertTrue(self.user in exps.administrators)
 
     def test_selected_experimentset_does_not_add_user_as_admin(self):
         data = self.post_data.copy()

--- a/dataset/tests/test_views_experiment.py
+++ b/dataset/tests/test_views_experiment.py
@@ -12,7 +12,6 @@ from accounts.permissions import (
     assign_user_as_instance_viewer,
     assign_user_as_instance_admin,
     assign_user_as_instance_editor,
-    user_is_admin_for_instance
 )
 
 from metadata.factories import (
@@ -259,9 +258,9 @@ class TestCreateNewExperimentView(TestCase, TestMessageMixin):
         data = self.post_data.copy()
         request = self.create_request(path=self.path, data=data, method='post')
         request.user = self.user
-        response = ExperimentCreateView.as_view()(request)
+        _ = ExperimentCreateView.as_view()(request)
         exp = Experiment.objects.all()[0]
-        self.assertTrue(user_is_admin_for_instance(self.user, exp))
+        self.assertFalse(self.user in exp.administrators)
 
     def test_new_experimentset_created_with_current_user_as_admin(self):
         data = self.post_data.copy()
@@ -270,7 +269,7 @@ class TestCreateNewExperimentView(TestCase, TestMessageMixin):
         _ = ExperimentCreateView.as_view()(request)
         exps = ExperimentSet.objects.first()
 
-        self.assertTrue(user_is_admin_for_instance(self.user, exps))
+        self.assertFalse(self.user in exps.administrators)
 
     def test_selected_experimentset_does_not_add_user_as_admin(self):
         data = self.post_data.copy()
@@ -281,7 +280,7 @@ class TestCreateNewExperimentView(TestCase, TestMessageMixin):
         request.user = self.user
         _ = ExperimentCreateView.as_view()(request)
 
-        self.assertFalse(user_is_admin_for_instance(self.user, es))
+        self.assertFalse(self.user in es.administrators)
 
     def test_failed_submission_adds_keywords_to_context(self):
         data = self.post_data.copy()

--- a/dataset/tests/test_views_experiment.py
+++ b/dataset/tests/test_views_experiment.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, mock
 from django.urls import reverse_lazy
 from django.http import Http404
 from django.core.exceptions import PermissionDenied
@@ -109,7 +109,6 @@ class TestExperimentDetailView(TestCase, TestMessageMixin):
         self.assertNotContains(response, 'Add a score set')
         self.assertNotContains(response, 'Edit this experiment')
         
-
 
 class TestCreateNewExperimentView(TestCase, TestMessageMixin):
     """

--- a/dataset/tests/test_views_scoreset.py
+++ b/dataset/tests/test_views_scoreset.py
@@ -16,7 +16,6 @@ from accounts.permissions import (
     assign_user_as_instance_viewer,
     assign_user_as_instance_editor,
     assign_user_as_instance_admin,
-    user_is_admin_for_instance
 )
 
 from core.utilities.tests import TestMessageMixin
@@ -489,7 +488,7 @@ class TestCreateNewScoreSetView(TransactionTestCase , TestMessageMixin):
         _ = ScoreSetCreateView.as_view()(request)
 
         scs = ScoreSet.objects.all()[0]
-        self.assertTrue(user_is_admin_for_instance(self.user, scs))
+        self.assertTrue(self.user in scs.administrators)
 
     def test_failed_submission_adds_extern_identifier_to_context(self):
         fs = [
@@ -590,9 +589,8 @@ class TestCreateNewScoreSetView(TransactionTestCase , TestMessageMixin):
         _ = ScoreSetCreateView.as_view()(request)
 
         scs = ScoreSet.objects.all()[0]
-        self.assertFalse(user_is_admin_for_instance(self.user, scs.parent))
-        self.assertFalse(user_is_admin_for_instance(
-            self.user, scs.parent.parent))
+        self.assertNotIn(self.user, scs.parent.administrators)
+        self.assertNotIn(self.user, scs.parent.parent.administrators)
 
     def test_ajax_submission_returns_json_response(self):
         data = self.post_data.copy()
@@ -655,9 +653,10 @@ class TestCreateNewScoreSetView(TransactionTestCase , TestMessageMixin):
         self.assertEqual(response.status_code, 302)
 
         scoreset = ScoreSet.objects.first()
-        user_is_admin_for_instance(scoreset, su)
-        user_is_admin_for_instance(scoreset.experiment, su)
-        user_is_admin_for_instance(scoreset.experiment.experimentset, su)
+
+        self.assertIn(su, scoreset.administrators)
+        self.assertIn(su, scoreset.parent.administrators)
+        self.assertIn(su, scoreset.parent.parent.administrators)
 
     def test_associates_new_uniprot_identifiers(self):
         data = self.post_data.copy()

--- a/dataset/tests/test_views_scoreset.py
+++ b/dataset/tests/test_views_scoreset.py
@@ -632,15 +632,12 @@ class TestCreateNewScoreSetView(TransactionTestCase , TestMessageMixin):
         self.assertNotContains(response, exp1.urn)
         self.assertContains(response, exp2.urn)
 
-    def test_create_sets_superusers_as_admins(self):
-        su = UserFactory()
-        su.is_superuser = True
-        su.save()
+    def test_create_not_set_superusers_as_admins(self):
+        su = UserFactory(is_superuser=True)
+        ScoreSet.objects.all().delete()
 
         data = self.post_data.copy()
         exp1 = ExperimentFactory()
-        scs1 = ScoreSetFactory(experiment=exp1)
-        assign_user_as_instance_admin(self.user, scs1)
         assign_user_as_instance_admin(self.user, exp1)
         data['experiment'] = [exp1.pk]
 
@@ -654,9 +651,9 @@ class TestCreateNewScoreSetView(TransactionTestCase , TestMessageMixin):
 
         scoreset = ScoreSet.objects.first()
 
-        self.assertIn(su, scoreset.administrators)
-        self.assertIn(su, scoreset.parent.administrators)
-        self.assertIn(su, scoreset.parent.parent.administrators)
+        self.assertNotIn(su, scoreset.administrators)
+        self.assertNotIn(su, scoreset.parent.administrators)
+        self.assertNotIn(su, scoreset.parent.parent.administrators)
 
     def test_associates_new_uniprot_identifiers(self):
         data = self.post_data.copy()

--- a/dataset/views/experiment.py
+++ b/dataset/views/experiment.py
@@ -91,6 +91,8 @@ class ExperimentCreateView(ExperimentAjaxMixin, CreateDatasetModelView):
         # by default a new experimentset is created with the current user
         # as it's administrator.
         experiment.add_administrators(self.request.user)
+        # assign_superusers_as_admin(experiment)
+
         experiment.set_created_by(self.request.user, propagate=False)
         experiment.set_modified_by(self.request.user, propagate=False)
         experiment.save(save_parents=False)

--- a/dataset/views/scoreset.py
+++ b/dataset/views/scoreset.py
@@ -4,6 +4,7 @@ import logging
 from functools import partial
 
 from django.db import transaction
+from django.contrib.auth import get_user_model
 from django.http import JsonResponse
 
 from reversion import create_revision
@@ -34,6 +35,7 @@ from .base import (
 )
 
 logger = logging.getLogger("django")
+User = get_user_model()
 
 
 def fire_task(request, scoreset, task_kwargs):
@@ -151,10 +153,10 @@ class ScoreSetCreateView(ScoreSetAjaxMixin, CreateDatasetModelView):
     
     success_message = (
         "Successfully created a new Scoreset with temporary accession number "
-        "{urn}. Uploaded files are being processed and further editing has been "
+        "{urn}. Uploaded files are being processed and further "
+        "editing has been "
         "temporarily disabled. Please check back later."
     )
-    
 
     def dispatch(self, request, *args, **kwargs):
         if self.request.GET.get("experiment", ""):
@@ -227,6 +229,7 @@ class ScoreSetCreateView(ScoreSetAjaxMixin, CreateDatasetModelView):
             scoreset.save()
        
         scoreset.add_administrators(self.request.user)
+        # assign_superusers_as_admin(scoreset)
         self.kwargs['urn'] = scoreset.urn
         return forms
 

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -99,6 +99,8 @@
     $.get(window.location.href, function (response) {
       let table = $("#search-table").DataTable({
         data: response,
+        bAutoWidth: true,
+        deferRender: true,
         columns: [
           {
             className: 'details-control',
@@ -152,7 +154,17 @@
       console.log(jqXHR.status);
       console.log(textStatus);
       console.log(errorThrown);
-      $("#search-loading p").text("Server error. Table could not be loaded.");
+
+      if (jqXHR.status === 500) {
+        $("#search-loading p").text(
+          "An internal server error has occurred during your search request."
+        );
+      } else {
+        $("#search-loading p").text(
+          "Your search request has failed with status " + jqXHR.status
+        );
+      }
+
       $("#search-loading .fa-spinner").remove();
       $("#search-loading .fa-frown").show()
     });


### PR DESCRIPTION
Major
-----
- Fixed permission bug in `GroupPermissionMixin`
- Improved efficiency in profile rendering
- Filtering display name now accepts CSV input
- scoreset list on experiment page shows current versions only
- Removed redundant calls to permission check
- Data usage policy only editable by administrators

Minor
-----
- Tables load in data via AJAX calls and display a loading spinner
- UI enhancements,and style updates
- Navbar groups all profile related pages into a dropdown with a profile icon
- Removed redundant calls to permission check
- Refactored several `GroupPermissionMixin` methods as properties