### PR TITLE
Adds two new manage.py commands to help with batch changes

### DIFF
--- a/data/main/site_info.json
+++ b/data/main/site_info.json
@@ -6,5 +6,5 @@
     "md_privacy": "",
     "md_terms": "",
     "md_usage_guide": "",
-    "version": "1.7.0"
+    "version": "1.7.1"
 }

--- a/dataset/constants.py
+++ b/dataset/constants.py
@@ -49,3 +49,8 @@ scoreset_to_variant_column = {
 processing = "processing"
 failed = "failed"
 success = "success"
+
+# User roles
+administrator = "administrator"
+editor = "editor"
+viewer = "viewer"

--- a/main/management/commands/addpmid.py
+++ b/main/management/commands/addpmid.py
@@ -1,0 +1,29 @@
+import sys
+from django.core.management.base import BaseCommand
+
+from urn.models import get_model_by_urn
+from metadata.models import PubmedIdentifier
+from metadata.validators import validate_pubmed_identifier
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--urn", type=str, help="Dataset URN")
+        parser.add_argument("--pmid", type=str, help="PubMed identifier")
+
+    def handle(self, *args, **kwargs):
+        urn = kwargs.get("urn", None)
+        if not urn:
+            raise ValueError("A valid URN is required.")
+
+        pmid = kwargs.get("pmid", None)
+        if not pmid:
+            raise ValueError("A PubMed ID is required.")
+        elif not validate_pubmed_identifier(pmid):
+            raise ValueError("A valid PubMed ID is required.")
+
+        pmid_instance, created = PubmedIdentifier.objects.get_or_create(identifier=pmid)
+        instance = get_model_by_urn(urn)
+        instance.pubmedids.add(pmid_instance)
+        instance.save()
+        sys.stderr.write("Added PMID {} to {}.\n".format(pmid, instance))

--- a/main/management/commands/addpmid.py
+++ b/main/management/commands/addpmid.py
@@ -19,11 +19,12 @@ class Command(BaseCommand):
         pmid = kwargs.get("pmid", None)
         if not pmid:
             raise ValueError("A PubMed ID is required.")
-        elif not validate_pubmed_identifier(pmid):
-            raise ValueError("A valid PubMed ID is required.")
+        validate_pubmed_identifier(pmid)
 
-        pmid_instance, created = PubmedIdentifier.objects.get_or_create(identifier=pmid)
+        pmid_instance, created = PubmedIdentifier.objects.get_or_create(
+            identifier=pmid
+        )
         instance = get_model_by_urn(urn)
-        instance.pubmedids.add(pmid_instance)
+        instance.pubmed_ids.add(pmid_instance)
         instance.save()
-        sys.stderr.write("Added PMID {} to {}.\n".format(pmid, instance))
+        sys.stdout.write("Added PMID {} to {}.\n".format(pmid, instance))

--- a/main/management/commands/adduser.py
+++ b/main/management/commands/adduser.py
@@ -23,8 +23,10 @@ class Command(BaseCommand):
         )
         if role not in valid_states:
             raise ValueError(
-                "Valid states are {}.".format("{} or {}".format(
-                    ", ".join(valid_states[:-1]), valid_states[-1])
+                "Valid states are {}.".format(
+                    "{} or {}".format(
+                        ", ".join(valid_states[:-1]), valid_states[-1]
+                    )
                 )
             )
 
@@ -47,4 +49,6 @@ class Command(BaseCommand):
         else:
             raise ValueError("Invalid user role.")
         instance.save()
-        sys.stderr.write("Added {} to {} with role {}.\n".format(user, instance, role))
+        sys.stdout.write(
+            "Added {} to {} with role {}.\n".format(user, instance, role)
+        )

--- a/main/management/commands/adduser.py
+++ b/main/management/commands/adduser.py
@@ -1,0 +1,50 @@
+import sys
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+from dataset import constants
+from urn.models import get_model_by_urn
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--user", type=str, help="User ORCID")
+        parser.add_argument("--urn", type=str, help="Dataset URN")
+        parser.add_argument("--role", type=str, help="User role")
+
+    def handle(self, *args, **kwargs):
+        role = kwargs.get("role", None)
+        valid_states = (
+            constants.administrator,
+            constants.editor,
+            constants.viewer,
+        )
+        if role not in valid_states:
+            raise ValueError(
+                "Valid states are {}.".format("{} or {}".format(
+                    ", ".join(valid_states[:-1]), valid_states[-1])
+                )
+            )
+
+        urn = kwargs.get("urn", None)
+        if not urn:
+            raise ValueError("A valid URN is required.")
+
+        user = kwargs.get("user", None)
+        if not user:
+            raise ValueError("A valid user is required.")
+
+        instance = get_model_by_urn(urn)
+        user_model = User.objects.get(username=user)
+        if role == constants.administrator:
+            instance.add_administrators(user_model)
+        elif role == constants.editor:
+            instance.add_editors(user_model)
+        elif role == constants.viewer:
+            instance.add_viewers(user_model)
+        else:
+            raise ValueError("Invalid user role.")
+        instance.save()
+        sys.stderr.write("Added {} to {} with role {}.\n".format(user, instance, role))

--- a/main/tests/test_commands.py
+++ b/main/tests/test_commands.py
@@ -1,0 +1,142 @@
+from django.test import TestCase
+from django.core.management import call_command
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
+
+from accounts.factories import UserFactory
+from dataset.factories import ScoreSetFactory
+from metadata.factories import PubmedIdentifierFactory
+from metadata.models import PubmedIdentifier
+from dataset import constants
+
+
+class TestAddPmidCommand(TestCase):
+    def test_value_error_invalid_urn(self):
+        with self.assertRaises(ValueError):
+            call_command("addpmid", pmid="25075907", urn=None)
+
+    def test_validation_error_invalid_pmid(self):
+        instance = ScoreSetFactory()
+
+        with self.assertRaises(ValidationError):
+            call_command("addpmid", pmid="abc", urn=instance.urn)
+
+        with self.assertRaises(ValueError):
+            call_command("addpmid", pmid=None, urn=instance.urn)
+
+    def test_retrieves_existing_pmid(self):
+        instance = ScoreSetFactory()
+        pmid = "25075907"
+        PubmedIdentifier.objects.all().delete()
+        PubmedIdentifierFactory(identifier=pmid)
+
+        self.assertEqual(PubmedIdentifier.objects.count(), 1)
+        call_command("addpmid", pmid=pmid, urn=instance.urn)
+
+        pmid_instance = PubmedIdentifier.objects.first()
+        self.assertEqual(PubmedIdentifier.objects.count(), 1)
+        self.assertEqual(pmid_instance.identifier, pmid)
+        self.assertIsNotNone(pmid_instance.reference_html)
+        self.assertIn(pmid_instance, instance.pubmed_ids.all())
+
+    def test_creates_new_pmid(self):
+        instance = ScoreSetFactory()
+        pmid = "25075907"
+        PubmedIdentifier.objects.all().delete()
+
+        self.assertEqual(PubmedIdentifier.objects.count(), 0)
+        call_command("addpmid", pmid=pmid, urn=instance.urn)
+
+        pmid_instance = PubmedIdentifier.objects.first()
+        self.assertEqual(PubmedIdentifier.objects.count(), 1)
+        self.assertEqual(pmid_instance.identifier, pmid)
+        self.assertIsNotNone(pmid_instance.reference_html)
+        self.assertIn(pmid_instance, instance.pubmed_ids.all())
+
+
+class TestAddUserCommand(TestCase):
+    def test_error_invalid_urn(self):
+        user = UserFactory()
+
+        with self.assertRaises(ValueError):
+            call_command(
+                "adduser",
+                user=user.username,
+                urn=None,
+                role=constants.administrator,
+            )
+
+    def test_error_urn_doesnt_exist(self):
+        user = UserFactory()
+        with self.assertRaises(ObjectDoesNotExist):
+            call_command(
+                "adduser",
+                user=user.username,
+                urn="urn:mavedb:00000001-a-1",
+                role=constants.administrator,
+            )
+
+    def test_error_invalid_username(self):
+        instance = ScoreSetFactory()
+        with self.assertRaises(ValueError):
+            call_command(
+                "adduser",
+                user=None,
+                urn=instance.urn,
+                role=constants.administrator,
+            )
+
+    def test_error_user_doesnt_exist(self):
+        instance = ScoreSetFactory()
+        with self.assertRaises(ObjectDoesNotExist):
+            call_command(
+                "adduser",
+                user="user_a",
+                urn=instance.urn,
+                role=constants.administrator,
+            )
+
+    def test_error_invalid_role(self):
+        user = UserFactory()
+        instance = ScoreSetFactory()
+
+        with self.assertRaises(ValueError):
+            call_command(
+                "adduser",
+                user=user.username,
+                urn=instance.urn,
+                role="not a role",
+            )
+
+    def test_adds_user_to_role(self):
+        user = UserFactory()
+        instance = ScoreSetFactory()
+
+        call_command(
+            "adduser",
+            user=user.username,
+            urn=instance.urn,
+            role=constants.administrator,
+        )
+        self.assertIn(user, instance.administrators)
+        self.assertNotIn(user, instance.editors)
+        self.assertNotIn(user, instance.viewers)
+
+        call_command(
+            "adduser",
+            user=user.username,
+            urn=instance.urn,
+            role=constants.editor,
+        )
+        self.assertIn(user, instance.editors)
+        self.assertNotIn(user, instance.administrators)
+        self.assertNotIn(user, instance.viewers)
+
+        call_command(
+            "adduser",
+            user=user.username,
+            urn=instance.urn,
+            role=constants.viewer,
+        )
+        self.assertIn(user, instance.viewers)
+        self.assertNotIn(user, instance.administrators)
+        self.assertNotIn(user, instance.editors)


### PR DESCRIPTION
Added new `manage.py` commands:

* `python manage.py adduser --user ORCID --urn URN --role (administrator|editor|viewer)` 
* `python manage.py addpmid --urn URN --pmid PMID`

Each modifies a single entry, but can be used in a shell script to batch-update multiple records.