### PR TITLE
Bump mavehgvs version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,4 +27,4 @@ pandas==1.1.2
 numpy==1.19.1
 sphinx==3.2.1
 fqfa>=1.2.1
-mavehgvs>=0.2.1
+mavehgvs>=0.4.0


### PR DESCRIPTION
Updates mavehgvs to fix a bug with validating equality variants and support MITE-seq style variants.