### PR TITLE
Add a CORS header allowing browser-based clients to consume the API.

### DIFF
--- a/middleware/cors.py
+++ b/middleware/cors.py
@@ -1,0 +1,46 @@
+from django.utils.deprecation import MiddlewareMixin
+
+# This version supports Django 1.
+
+
+class CorsMiddleware(MiddlewareMixin):
+    """CORS middleware
+
+    Methods
+    -------
+    process_response(request, response)
+      Add a CORS header to the HTTP response.
+    """
+
+    def process_response(self, request, response):
+        """Add a CORS Access-Control-Allow-Origin=* header to the response.
+
+        This allows API responses to be consumed by browser-based clients.
+
+        Parameters
+        ----------
+        request : HttpRequest
+          The current HTTP request
+        response : HttpResponse
+          The HTTP response to which a CORS header should be added
+
+        Returns
+        -------
+        The HTTP response
+        """
+        response["Access-Control-Allow-Origin"] = "*"
+        return response
+
+
+# For later versions of Django:
+# def cors_middleware(get_response):
+#   # One-time configuration and initialization.
+#
+#   def middleware(request):
+#     # Code to be executed for each request before
+#     # the view (and later middleware) are called.
+#     response = get_response(request)
+#     response["Access-Control-Allow-Origin"] = "*"
+#     return response
+#
+#   return middleware

--- a/settings/base.py
+++ b/settings/base.py
@@ -103,6 +103,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "tracking.middleware.VisitorTrackingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "middleware.cors.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
The MaveDB API is publicly accessible and can be consumed by any client. However, it is currently consumed mainly by server-side clients such as mavevis. Browser-based clients, including any MaveDB client application that is not served by the Django application, generally require CORS headers granting explicit permission to consume the API. To allow this, we add a simple HTTP response header granting access to clients from any domain:
  Access-Control-Allow-Origin="*"

The header is added using Django middleware, with support for Django 1 (though a draft of a version for later Django versions is included and commented out). For current Django versions, there are also Django middleware packages available for this purpose, which provide configuration-driven CORS headers and are useful in case one wants to limit access to specific clients.